### PR TITLE
Fix collada_dom compilation by including sysroot i686 path

### DIFF
--- a/patches/collada_dom.patch
+++ b/patches/collada_dom.patch
@@ -16,7 +16,7 @@
  include(CheckTypeSize)
  find_package(PkgConfig)
  
-+set(CMAKE_CXX_FLAGS "-std=c++03")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
 +
  if( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )
    add_definitions("-fno-strict-aliasing -Wall")

--- a/utils.sh
+++ b/utils.sh
@@ -57,6 +57,7 @@ cmake_build() {
         -DPYTHON_EXECUTABLE=$python -DCMAKE_INSTALL_PREFIX=$target -DPCL_SHARED_LIBS=FALSE -DANDROID_ABI=$ANDROID_ABI \
         -DBOOST_INCLUDEDIR=$target/include -DBOOST_LIBRARYDIR=$target/lib -DBOOST_ROOT=/opt/roscpp_output/libs/boost \
         -DCMAKE_FIND_ROOT_PATH=$target \
+        -DCMAKE_CXX_FLAGS="-I/opt/android-ndk-r16b/sysroot/usr/include/i686-linux-android/" \
         -DANDROID_STL=c++_static
     make -j$PARALLEL_JOBS -l$PARALLEL_JOBS install
 }


### PR DESCRIPTION
We need to find a way of using variables to avoid hardcoded values in path. 