### PR TITLE
Install libc6-dev-i386 to avoid the lack of gnu/stubs.h

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,16 @@ RUN wget https://cmake.org/files/v3.11/cmake-3.11.3-Linux-x86_64.sh && \
   ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 
 # Install Android SDK
-RUN apt-get install -y openjdk-6-jdk lib32z1 lib32ncurses5 lib32bz2-1.0 lib32stdc++6 ant
+RUN apt-get update && \
+    apt-get install -y openjdk-6-jdk \
+                       lib32z1 \
+                       lib32ncurses5 \
+                       lib32bz2-1.0 \
+                       lib32stdc++6 \
+                       ant \
+                       libc6-dev-i386 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN wget http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz && tar -xvf android-sdk_r23.0.2-linux.tgz -C /opt && rm android-sdk_r23.0.2-linux.tgz
 
 # Set-up environment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,9 @@ RUN (while true; do echo 'y'; sleep 2; done) | android update sdk -u -t 2,3,7,8,
 ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64/
 
 # Use ccache
-RUN apt-get install -y ccache
+RUN apt-get update && \
+    apt-get install -y ccache \
+    && rm -rf /var/lib/apt/lists/*
 ENV USE_CCACHE 1
 ENV NDK_CCACHE /usr/bin/ccache
 ENV CCACHE_DIR /opt/roscpp_output/ccache


### PR DESCRIPTION
Seems like libc++ is expecting the system to have the gnu/stubs.h file, the [problem was reported](https://github.com/PaddlePaddle/Paddle/issues/9285) in other projects before. The compilation error in rostime is:

```shell
Scanning dependencies of target rostime
make[2]: Leaving directory `/opt/roscpp_output/catkin_ws/build'
make -f roscpp_core/rostime/CMakeFiles/rostime.dir/build.make roscpp_core/rostime/CMakeFiles/rostime.dir/build
make[2]: Entering directory `/opt/roscpp_output/catkin_ws/build'
[  0%] Building CXX object roscpp_core/rostime/CMakeFiles/rostime.dir/src/duration.cpp.o
cd /opt/roscpp_output/catkin_ws/build/roscpp_core/rostime && /opt/android-ndk-r17b/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=i686-none-linux-android --gcc-toolchain=/opt/android-ndk-r17b/toolchains/x86-4.9/prebuilt/linux-x86_64 --sysroot=/opt/android-ndk-r17b/sysroot   -I/opt/roscpp_output/catkin_ws/src/roscpp_core/rostime/include -I/opt/roscpp_output/catkin_ws/src/roscpp_core/cpp_common/include -I/opt/roscpp_output/target/include -I/usr/include -isystem /opt/android-ndk-r17b/sources/cxx-stl/llvm-libc++/include -isystem /opt/android-ndk-r17b/sources/android/support/include -isystem /opt/android-ndk-r17b/sources/cxx-stl/llvm-libc++abi/include  -isystem /opt/android-ndk-r17b/sysroot/usr/include/i686-linux-android -D__ANDROID_API__=14 -g -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -mstackrealign -Wa,--noexecstack -Wformat -Werror=format-security -std=c++11  -O2 -DNDEBUG    -o CMakeFiles/rostime.dir/src/duration.cpp.o -c /opt/roscpp_output/catkin_ws/src/roscpp_core/rostime/src/duration.cpp
In file included from /opt/roscpp_output/catkin_ws/src/roscpp_core/rostime/src/duration.cpp:34:
In file included from /opt/roscpp_output/catkin_ws/src/roscpp_core/rostime/include/ros/duration.h:49:
In file included from /opt/android-ndk-r17b/sources/cxx-stl/llvm-libc++/include/iostream:37:
In file included from /opt/android-ndk-r17b/sources/cxx-stl/llvm-libc++/include/__config:169:
/usr/include/features.h:398:10: fatal error: 'gnu/stubs.h' file not found
#include <gnu/stubs.h>
         ^~~~~~~~~~~~~
1 warning generated.
```

After installing the package, the error is gone.