### PR TITLE
Update android NDK to latest version r17b

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,12 +9,12 @@ RUN wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | s
 RUN apt-get update && apt-get install --no-install-recommends -y ros-indigo-ros-base python-wstool
 
 # Install Android NDK
-RUN wget https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip && \
-  unzip android-ndk-r16b-linux-x86_64.zip -d /opt && \
-  rm android-ndk-r16b-linux-x86_64.zip
+RUN wget https://dl.google.com/android/repository/android-ndk-r17b-linux-x86_64.zip && \
+  unzip android-ndk-r17b-linux-x86_64.zip -d /opt && \
+  rm android-ndk-r17b-linux-x86_64.zip
 
 # Set-up environment
-ENV ANDROID_NDK /opt/android-ndk-r16b
+ENV ANDROID_NDK /opt/android-ndk-r17b
 
 # Install g++ to avoid "CMAKE_CXX_COMPILER-NOTFOUND was not found." error
 RUN apt-get install -y g++ make python-lxml


### PR DESCRIPTION
While compiling the new version of rospack available, the compiler reported many problems related to headers:

```shell
Error:(36, 2) error: Bionic header ctype.h does not define either _U nor _CTYPE_U
Error:(62, 35) error: use of undeclared identifier '_CTYPE_U'
Information:(38, 12) expanded from macro '_U' ...
```
This was reported upstream in https://github.com/android-ndk/ndk/issues/404. The suggested solution is to use [unifiers headers](https://android.googlesource.com/platform/ndk/+/ndk-r14-release/docs/UnifiedHeaders.md#CMake) which seems the default option for new ndks so I preferred to update the ndk before compiling it from source. There are still errors with some other headers, but the problems with "CTYPE" are gone.